### PR TITLE
fix: define missing CALENDARIO_BUILTIN constant in spazzatura.py

### DIFF
--- a/homemind-orchestrator/src/spazzatura.py
+++ b/homemind-orchestrator/src/spazzatura.py
@@ -20,6 +20,8 @@ from datetime import datetime, timedelta
 from utils.timezone_helper import now_local
 from pathlib import Path
 
+_BUILTIN_FILE = Path(__file__).parent.parent / "spazzatura_calendario_lanciano_2026.json"
+CALENDARIO_BUILTIN = _BUILTIN_FILE.read_text(encoding="utf-8") if _BUILTIN_FILE.exists() else "{}"
 logger = logging.getLogger("homemind.spazzatura")
 
 def _find_config_dir() -> Path:


### PR DESCRIPTION
The constant CALENDARIO_BUILTIN was used in two places (start() and reload() methods) but was never defined, causing a NameError crash on every startup.

Fix: load the constant from the spazzatura_calendario_lanciano_2026.json file that already exists in the repo root (homemind-orchestrator/). If the file is not found (e.g. different installation), fall back to an empty JSON string "{}" so the add-on can still start without crashing.

Fixes: add-on crashing immediately on startup with:
  NameError: name 'CALENDARIO_BUILTIN' is not defined
  ERROR: Application startup failed. Exiting.